### PR TITLE
Fix browser usage typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ npm install jsdom
 ### Browser
 
 ```javascript
-import { Defuddle } from 'defuddle';
+import Defuddle from 'defuddle';
 
 // Parse the current document
 const defuddle = new Defuddle(document);


### PR DESCRIPTION
https://github.com/kepano/defuddle/blob/cb4291db0f24cac0d0674d9e35fc0089338da2da/src/index.ts#L5

The example code here for the browser is slightly off. `Defuddle` is exported as default, which means we can import it directly.

It used to be correct, but got mixed up when adding the Node example code here: https://github.com/kepano/defuddle/pull/25